### PR TITLE
fix #256 from  arquillian / arquillian.github.com

### DIFF
--- a/arquillian-tutorial-rinse-repeat/src/test/java/org/arquillian/example/BasketTest.java
+++ b/arquillian-tutorial-rinse-repeat/src/test/java/org/arquillian/example/BasketTest.java
@@ -30,6 +30,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+
 /**
  * @author <a href="http://community.jboss.org/people/dan.j.allen">Dan Allen</a>
  */
@@ -68,5 +72,6 @@ public class BasketTest {
     @InSequence(2)
     public void order_should_be_persistent() {
         Assert.assertEquals(2, repo.getOrderCount());
+        Assert.assertThat("First order must have sunglasses on its 1. position","sunglasses", is(repo.getOrders().get(0).get(0)));
     }
 }

--- a/arquillian-tutorial-rinse-repeat/src/test/java/org/arquillian/example/SingletonOrderRepository.java
+++ b/arquillian-tutorial-rinse-repeat/src/test/java/org/arquillian/example/SingletonOrderRepository.java
@@ -37,7 +37,7 @@ public class SingletonOrderRepository implements OrderRepository {
     @Override
     @Lock(LockType.WRITE)
     public void addOrder(List<String> order) {
-        orders.add(order);
+        orders.add(new ArrayList<String>(order));
     }
     
     @Override


### PR DESCRIPTION
Basket class contains `List<String>` of items. Function `basket.placeOrder()` pass this item's list to another list inside **SingletonOrderRepository.class** and than this list is cleared via `items.clear()`. This is problem because  value is pass via reference copy and list inside **SingletonOrderRepository** is cleared also.

Arquillian's tests looks ok on first sight because they testing only size not what they are really holding inside. 

You need eather 
`items = new ArrayList<String>()` instead of `items.clear()` inside **Basket.class**

or 

`orders.add(new ArrayList<String>(order));`
instead of `orders.add(order);` inside **SingletonOrderRepository.class**
