### PR TITLE
Fixed groupId and version in pom.xml files

### DIFF
--- a/arquillian-drone-tutorial/pom.xml
+++ b/arquillian-drone-tutorial/pom.xml
@@ -6,9 +6,9 @@
         http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.arquillian.example</groupId>
+    <groupId>org.jboss.arquillian.examples</groupId>
     <artifactId>arquillian-drone-tutorial</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>arquillian-drone-tutorial</name>

--- a/arquillian-jpa-drone/pom.xml
+++ b/arquillian-jpa-drone/pom.xml
@@ -4,9 +4,9 @@
     					http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.arquillian.example</groupId>
+    <groupId>org.jboss.arquillian.examples</groupId>
     <artifactId>arquillian-jpa-drone</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>arquillian-jpa-drone</name>

--- a/arquillian-persistence-tutorial/pom.xml
+++ b/arquillian-persistence-tutorial/pom.xml
@@ -6,9 +6,9 @@
         http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.arquillian.example</groupId>
+    <groupId>org.jboss.arquillian.examples</groupId>
     <artifactId>arquillian-persistence-tutorial</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Arquillian Persistence Tutorial</name>

--- a/arquillian-tutorial-rinse-repeat/pom.xml
+++ b/arquillian-tutorial-rinse-repeat/pom.xml
@@ -6,9 +6,9 @@
         http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.arquillian.example</groupId>
+    <groupId>org.jboss.arquillian.examples</groupId>
     <artifactId>arquillian-tutorial-rinse-repeat</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>arquillian-tutorial</name>

--- a/arquillian-tutorial/pom.xml
+++ b/arquillian-tutorial/pom.xml
@@ -6,9 +6,9 @@
         http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.arquillian.example</groupId>
+    <groupId>org.jboss.arquillian.examples</groupId>
     <artifactId>arquillian-tutorial</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>arquillian-tutorial</name>
@@ -61,6 +61,9 @@
     <profiles>
         <profile>
             <id>arquillian-weld-ee-embedded</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>org.jboss.spec</groupId>

--- a/ejb3-openejb/pom.xml
+++ b/ejb3-openejb/pom.xml
@@ -7,7 +7,6 @@
         <groupId>org.jboss.arquillian.examples</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <!-- Model Information -->

--- a/ejb31-gfembedded/pom.xml
+++ b/ejb31-gfembedded/pom.xml
@@ -7,7 +7,6 @@
 		<groupId>org.jboss.arquillian.examples</groupId>
 		<artifactId>parent</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<!-- Model Information -->

--- a/ejb31-jbembedded/pom.xml
+++ b/ejb31-jbembedded/pom.xml
@@ -7,7 +7,6 @@
         <groupId>org.jboss.arquillian.examples</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <!-- Model Information -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,10 @@
         http://maven.apache.org/POM/4.0.0
         http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
-    <groupId>org.arquillian.example</groupId>
+
+    <groupId>org.jboss.arquillian.examples</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Arquillian Examples Runner</name>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -7,7 +7,6 @@
 		<groupId>org.jboss.arquillian.examples</groupId>
 		<artifactId>parent</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
-		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<!-- Model Information -->
@@ -37,7 +36,7 @@
 		<jboss.domain>default</jboss.domain>
 		<!-- The version of Weld extensions in use -->
 		<weld.extensions.version>1.0.0-CR2</weld.extensions.version>
-		<arquillian.version>1.0.0.Alpha5</arquillian.version>
+		<arquillian.version>1.0.0.CR3</arquillian.version>
 	</properties>
 
 	<!-- repositories configured in settings.xml -->


### PR DESCRIPTION
You could find : 
- both `org.jboss.arquillian.examples` and `org.arquillian.examples` group ids on the `pom.xml` files
- `1.0.0-SNAPSHOT` and `1.0-SNAPSHOT` versions

So some examples would not even compile. I've homogenized groupId and version, and got rid of `relativePath`.
