### PR TITLE
Fix outdated dependency

### DIFF
--- a/arquillian-tutorial/pom-no-container-profiles.xml
+++ b/arquillian-tutorial/pom-no-container-profiles.xml
@@ -48,8 +48,8 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Current dependency is generated an error and this file is being refered by http://arquillian.org/guides/getting_started/ when starting to work on arquillian

#### Short description of what this resolves:
Right now http://arquillian.org/guides/getting_started/ is telling you to replace with the contents of this edited file your pom if you are having problems, but this pom generates a problem when you try to run the test as the dependency is outdated

#### Changes proposed in this pull request:

- updates the required dependency for successful tests